### PR TITLE
Potential fix for code scanning alert no. 236: DOM text reinterpreted as HTML

### DIFF
--- a/admin-dev/themes/default/example/components/panels-complex.html
+++ b/admin-dev/themes/default/example/components/panels-complex.html
@@ -15,7 +15,7 @@
      <i class="process-icon-refresh"></i>
      </span>
      </a>
-     <a class="list-toolbar-btn" href="javascript:void(0);" onclick="$('.leadin').first().append('<div class=\'alert alert-info\'>' + $('#sql_query_tax_rules_group').val() + '</div>'); $(this).attr('onclick', '');">
+     <a class="list-toolbar-btn" href="javascript:void(0);" onclick="$('.leadin').first().append($('<div class=\'alert alert-info\'></div>').text($('#sql_query_tax_rules_group').val())); $(this).attr('onclick', '');">
      <span class="label-tooltip" data-toggle="tooltip" data-original-title="Voir la requête SQL" data-html="true" data-placement="top">
      <i class="process-icon-terminal"></i>
      </span>


### PR DESCRIPTION
Potential fix for [https://github.com/Shivam7-1/PrestaShop/security/code-scanning/236](https://github.com/Shivam7-1/PrestaShop/security/code-scanning/236)

To fix the problem, we need to ensure that any text content retrieved from the DOM and inserted back into the DOM is properly escaped to prevent XSS attacks. The best way to fix this issue is to use a method that safely inserts text content into the DOM without interpreting it as HTML.

In this case, we can use `text()` instead of `html()` to insert the content safely. This ensures that any special characters in the text are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
